### PR TITLE
Added positionMillis() to ResamplingArrayReader.h

### DIFF
--- a/src/ResamplingArrayReader.h
+++ b/src/ResamplingArrayReader.h
@@ -40,6 +40,20 @@ public:
     File open(char *filename) override {
         return File();
     }
+
+    uint32_t positionMillis(void) {
+    if (_file_size == 0) return 0;
+//    if (!_useDualPlaybackHead) {
+            return (uint32_t) (( (double)_bufferPosition1 * lengthMillis() ) / (double)(_file_size/2));
+//        } else {
+//            if (_crossfade < 0.5)
+//                return (uint32_t) (( (double)_bufferPosition1 * lengthMillis() ) / (double)(_file_size/2));
+//            else
+//                // this one causes the playhead to be reported at the start or end of the loop, no movement at all
+//                return (uint32_t) (( (double)_bufferPosition2 * lengthMillis() ) / (double)(_file_size/2));
+//        }
+//    }
+    
 protected:
 };
 

--- a/src/ResamplingReader.h
+++ b/src/ResamplingReader.h
@@ -646,7 +646,11 @@ public:
     }
 
     void setCrossfadeDurationInSamples(unsigned int crossfadeDurationInSamples) {
-        _crossfadeDurationInSamples = crossfadeDurationInSamples;
+        uint32_t loopLength = _loop_finish - _loop_start;
+        if (crossfadeDurationInSamples > loopLength / 2) {
+            crossfadeDurationInSamples = loopLength / 2;
+        }
+	    _crossfadeDurationInSamples = crossfadeDurationInSamples;
     }
 
     void setInterpolationType(ResampleInterpolationType interpolationType) {


### PR DESCRIPTION
AudioPlayArrayResmp::positionMillis() always returns the total file duration instead of current playback position, making it useless for progress tracking.